### PR TITLE
chore: ignore environment variable files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ dist
 dist-ssr
 *.local
 
+.env
+.env.staging
+.env.production
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json


### PR DESCRIPTION
Add .env, .env.staging, and .env.production to .gitignore to prevent sensitive environment configuration files from being committed to the repository. This helps improve security and keeps environment-specific settings local to each developer or deployment environment.