### PR TITLE
feat(selfServe): add address2 field and webhook call on step4

### DIFF
--- a/src/lib/attributes.ts
+++ b/src/lib/attributes.ts
@@ -46,6 +46,7 @@ export const selectors = {
   seperateContactName: `[${prefix}=seperate-contact-name]`,
   contractDetailsName: `[${prefix}=contract-details-name]`,
   contractDetailsAddress: `[${prefix}=contract-details-address]`,
+  contractDetailsAddress2: `[${prefix}=contract-details-address-2]`,
   contractDetailsCompany: `[${prefix}=contract-details-company]`,
   contractDetailsCompanyLegalName: `[${prefix}=contract-details-company-legal-name]`,
 

--- a/src/lib/selfServe.ts
+++ b/src/lib/selfServe.ts
@@ -161,6 +161,20 @@ export class SelfServe {
 
   private validateStep4() {
     cart.value.currentStep++;
+    (async () => {
+      const response = await fetch(
+        `https://finsweet-intelligence.app.n8n.cloud/webhook-test/client-onboarding`,
+        {
+          method: "POST",
+          body: JSON.stringify(cart.value),
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }
+      );
+      const data = await response.json();
+      console.log(data);
+    })();
   }
 
   private loadAllServices() {
@@ -268,6 +282,9 @@ export class SelfServe {
     const contractDetailsAddress = document.querySelector(
       selectors.contractDetailsAddress
     ) as HTMLInputElement;
+    const contractDetailsAddress2 = document.querySelector(
+      selectors.contractDetailsAddress2
+    ) as HTMLInputElement;
     const contractDetailsCompany = document.querySelector(
       selectors.contractDetailsCompany
     ) as HTMLInputElement;
@@ -307,6 +324,11 @@ export class SelfServe {
       e.preventDefault();
       const addressValue = (e.target as HTMLInputElement).value;
       cart.value.contractDetails.address = addressValue;
+    });
+    contractDetailsAddress2.addEventListener("change", (e: Event) => {
+      e.preventDefault();
+      const address2Value = (e.target as HTMLInputElement).value;
+      cart.value.contractDetails.address2 = address2Value;
     });
     contractDetailsCompany.addEventListener("change", (e: Event) => {
       e.preventDefault();
@@ -680,6 +702,9 @@ export class SelfServe {
     const contractDetailsAddress = document.querySelector(
       selectors.contractDetailsAddress
     ) as HTMLInputElement;
+    const contractDetailsAddress2 = document.querySelector(
+      selectors.contractDetailsAddress2
+    ) as HTMLInputElement;
     const contractDetailsCompany = document.querySelector(
       selectors.contractDetailsCompany
     ) as HTMLInputElement;
@@ -692,6 +717,7 @@ export class SelfServe {
       submitterEmail.value = cart.value.submitterDetails.email;
       contractDetailsName.value = cart.value.contractDetails.name;
       contractDetailsAddress.value = cart.value.contractDetails.address;
+      contractDetailsAddress2.value = cart.value.contractDetails.address2;
       contractDetailsCompany.value = cart.value.contractDetails.company;
       contractDetailsCompanyLegalName.value =
         cart.value.contractDetails.companyLegalName;

--- a/src/stores/cart.ts
+++ b/src/stores/cart.ts
@@ -6,6 +6,7 @@ const emptyCartState: Cart = {
   contractDetails: {
     name: "",
     address: "",
+    address2: "",
     company: "",
     companyLegalName: "",
   },
@@ -133,6 +134,7 @@ export type Package = {
 type ContractDetails = {
   name: string;
   address: string;
+  address2: string;
   company: string;
   companyLegalName: string;
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,7 +28,10 @@ export default defineConfig(({ mode }) => ({
   //cors durring dev
   server: {
     cors: {
-      origin: ["https://fs-self-service.webflow.io"],
+      origin: [
+        "https://fs-self-service.webflow.io",
+        "https://finsweet.webflow.io",
+      ],
       methods: "GET,HEAD,PUT,PATCH,POST,DELETE",
     },
     allowedHosts: ["fs-search-sandbox.webflow.io", "local5173-70.localcan.dev"],


### PR DESCRIPTION
Add a new contractDetails.address2 field with corresponding DOM bindings and event listeners to capture secondary address input. Update cart store and attribute selectors to include address2. Enhance CORS config to allow additional origins for development. Implement an async POST request to send cart data to a webhook endpoint upon completing step 4, enabling external client onboarding integration.